### PR TITLE
add set_tlsext_host_name to get working on openshift

### DIFF
--- a/check_certificate_chain.py
+++ b/check_certificate_chain.py
@@ -29,6 +29,7 @@ def main():
     tls_context.set_verify(M2Crypto.SSL.verify_none, False)
  
     conn = M2Crypto.SSL.Connection(tls_context)
+    conn.set_tlsext_host_name(sys.argv[1])
     conn.connect((server, port))
  
     chain = conn.get_peer_cert_chain()


### PR DESCRIPTION
Set TLS extension servername in ClientHello to get it working on openshift.
Further details on https://docs.openshift.com/enterprise/3.2/architecture/core_concepts/routes.html#secured-routes