### PR TITLE
fix error if get_value return no value

### DIFF
--- a/check_certificate_chain.py
+++ b/check_certificate_chain.py
@@ -57,7 +57,8 @@ def main():
         print "- [X.509 Extension Details]:"
         for k in range(0, cert.get_ext_count()):
             ext = cert.get_ext_at(k)
-            print "  `-- [x509_" + ext.get_name() + "]:\n\t   %s\n" % ext.get_value().replace('\n', ' ')
+            if ext.get_value():
+                print "  `-- [x509_" + ext.get_name() + "]:\n\t   %s\n" % ext.get_value().replace('\n', ' ')
         print "- [Fingerprint]:\t(hex) %s"  % cert.get_fingerprint()
         print "- [Keysize]:\t\t%s Bits"     % (pkey.size() * 8)
         print "- [RSA Modulus]:\t(hex) %s"  % pkey.get_modulus()


### PR DESCRIPTION
handle extenstion attributes without values (maybe invalid certificate).

```
Traceback (most recent call last):
  File "./check_certificate_chain.py", line 71, in <module>
    main()
  File "./check_certificate_chain.py", line 60, in main
    print "  `-- [x509_" + ext.get_name() + "]:\n\t   %s\n" % ext.get_value().replace('\n', ' ')
AttributeError: 'NoneType' object has no attribute 'replace'
```

x509 extenstion name: UNDEF